### PR TITLE
Фикс для siptv.eu

### DIFF
--- a/plugins/modules/PlaylistGenerator.py
+++ b/plugins/modules/PlaylistGenerator.py
@@ -96,7 +96,7 @@ class PlaylistGenerator(object):
                     item['url'] = re.sub('^([0-9]+)$', lambda match: 'http://' + hostport + path + '/channels/play?id=' + match.group(0),
                                             url, flags=re.MULTILINE)
                 if url == item['url']:  # For channel names
-                    item['url'] = re.sub('^([^/]+)$', lambda match: 'http://' + hostport + path + '/' + match.group(0),
+                    item['url'] = re.sub('^([^/]+)$', lambda match: 'http://' + hostport + path + '/' + match.group(0) + '/stream.mp4',
                                             url, flags=re.MULTILINE)
             
             if fmt:

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '') + 'test12.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '') + urllib2.quote('/') + 'stream.mp4'
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -116,7 +116,7 @@ class Torrenttv(AceProxyPlugin):
                     connection.dieWithError(404, 'Invalid path: ' + path, logging.DEBUG)
                     return
                 
-                name = urllib2.unquote(path[19:-4]).decode('UTF8')
+                name = urllib2.unquote(path[19:-11]).decode('UTF8')
                 url = self.channels.get(name)
                 if not url:
                     connection.dieWithError(404, 'Unknown channel: ' + name, logging.DEBUG)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '') + '.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '') + '/stream.mp4'
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '/') + 'stream.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '')
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '') + '/stream.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '') + '.mp4'
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '') + '.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '') + 'test12.mp4'
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)

--- a/plugins/torrenttv_plugin.py
+++ b/plugins/torrenttv_plugin.py
@@ -65,7 +65,7 @@ class Torrenttv(AceProxyPlugin):
 
                 if (url.startswith('acestream://')) or (url.startswith('http://') and url.endswith('.acelive')):
                     self.channels[name] = url
-                    itemdict['url'] = urllib2.quote(encname, '') + urllib2.quote('/') + 'stream.mp4'
+                    itemdict['url'] = urllib2.quote(encname, '/') + 'stream.mp4'
 
                 self.playlist.addItem(itemdict)
                 m.update(encname)


### PR DESCRIPTION
Siptv.eu не воспринимает адекватно плейлисты не заканчивающиеся на /stream.mp4 

поправил генерацию ссылок для плейлиста 
Раньше они выглядели так:
http://host:port/torrenttv/channel/0x0%20Fireplace%20HD.mp4
теперь они выглядят таким образом: 
http://host:port/torrenttv/channel/0x0%20Fireplace%20HD/stream.mp4


